### PR TITLE
infiniband.rb: Workaround for missing Facter::Util::FileRead.

### DIFF
--- a/lib/facter/util/infiniband.rb
+++ b/lib/facter/util/infiniband.rb
@@ -31,7 +31,7 @@ class Facter::Util::Infiniband
   #
   # @api private
   def self.read_sysfs(path)
-    output = Facter::Util::FileRead.read(path)
+    output = Facter::Util::Resolution.exec(['cat ',path].join()) if File.exist?(path)
     return nil if output.nil?
     output.strip
   end


### PR DESCRIPTION
This util got dropped in facter 3, which is now part of
puppetlabs PC1.

This works around the issue outlined in #6 .