### PR TITLE
Added support for CentOS/RedHat 7.4.  

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,39 @@ class infiniband::params {
 
   case $::osfamily {
     'RedHat': {
-      if versioncmp($::operatingsystemmajrelease, '7') == 0 {
+      if versioncmp($::operatingsystemrelease, "7.4.1708") == 0 {
+        $base_packages = [
+          'dapl',
+          'ibacm',
+          'iwpmd',
+          'ibutils',
+          'infiniband-diags',
+          'libibcm',
+          'libibmad',
+          'libibumad',
+          'libibverbs-13',
+          'libibverbs-utils-13',
+          'librdmacm',
+          'librdmacm-utils',
+          'mstflint',
+          'opa-address-resolution',
+          'opa-fastfabric',
+          'perftest',
+          'srp_daemon',
+        ]
+
+        $optional_packages = [
+          'compat-dapl',
+          'compat-opensm-libs',
+          'libibcommon',
+          'libusnic_verbs',
+          'libvma',
+          'opensm',
+          'rdma-core',
+          'qperf',
+          'usnic-tools',
+        ]
+      } elsif versioncmp($::operatingsystemmajrelease, '7') == 0 {
         $base_packages = [
           'dapl',
           'ibacm',


### PR DESCRIPTION
Many packages were rolled into existing meta-packages, and some packages were renamed.  Changes loosely based off of mrolli's comments on the open issue.

Tested with Centos 7.4, but I did not have a RHEL 7.4 installation to test on.