### PR TITLE
Adds support for EL-7.4.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,38 @@ class infiniband::params {
 
   case $::osfamily {
     'RedHat': {
-      if versioncmp($::operatingsystemmajrelease, '7') == 0 {
+      if versioncmp($::operatingsystemrelease, '7.4') >= 0 {
+        $base_packages = [
+          'dapl',
+          'ibacm',
+          'ibutils',
+          'infiniband-diags',
+          'iwpmd',
+          'libibcm',
+          'libibmad',
+          'libibumad',
+          'libibverbs',
+          'libibverbs-utils',
+          'librdmacm',
+          'librdmacm-utils',
+          'mstflint',
+          'opa-address-resolution',
+          'opa-fastfabric',
+          'perftest',
+          'qperf',
+          'srp_daemon',
+        ]
+
+        $optional_packages = [
+          'compat-dapl',
+          'compat-opensm-libs',
+          'libibcommon',
+          'libusnic_verbs',
+          'libvma',
+          'rdma-core',
+          'usnic-tools',
+        ]
+      } elsif versioncmp($::operatingsystemmajrelease, '7') == 0 {
         $base_packages = [
           'dapl',
           'ibacm',

--- a/spec/acceptance/infiniband_spec.rb
+++ b/spec/acceptance/infiniband_spec.rb
@@ -1,6 +1,70 @@
 require 'spec_helper_acceptance'
 
 describe 'infiniband class' do
+  case fact('operatingsystemrelease')
+    when '7.4', '7.4.1708'
+      base_pkgs = [
+        'dapl',
+        'ibacm',
+        'ibutils',
+        'infiniband-diags',
+        'iwpmd',
+        'libibcm',
+        'libibmad',
+        'libibumad',
+        'libibverbs',
+        'libibverbs-utils',
+        'librdmacm',
+        'librdmacm-utils',
+        'mstflint',
+        'opa-address-resolution',
+        'opa-fastfabric',
+        'perftest',
+        'qperf',
+        'srp_daemon',
+      ]
+
+      opt_pkgs = [
+        'compat-dapl',
+        'compat-opensm-libs',
+        'libibcommon',
+        'libusnic_verbs',
+        'libvma',
+        'rdma-core',
+        'usnic-tools',
+      ]
+    else
+      base_pkgs = [
+        'libibcm',
+        'libibverbs',
+        'libibverbs-utils',
+        'librdmacm',
+        'librdmacm-utils',
+        'rdma',
+        'dapl',
+        'ibacm',
+        'ibutils',
+        'libcxgb3',
+        'libibmad',
+        'libibumad',
+        'libipathverbs',
+        'libmlx4',
+        'libmthca',
+        'libnes',
+      ]
+
+      opt_pkgs = [
+        'compat-dapl',
+        'infiniband-diags',
+        'libibcommon',
+        'mstflint',
+        'perftest',
+        'qperf',
+        'srptools',
+      ]
+  end
+
+
   context 'default parameters' do
     it 'should run successfully' do
       pp =<<-EOS
@@ -11,38 +75,13 @@ describe 'infiniband class' do
       apply_manifest(pp, :catch_changes => true)
     end
 
-    [
-      'libibcm',
-      'libibverbs',
-      'libibverbs-utils',
-      'librdmacm',
-      'librdmacm-utils',
-      'rdma',
-      'dapl',
-      'ibacm',
-      'ibutils',
-      'libcxgb3',
-      'libibmad',
-      'libibumad',
-      'libipathverbs',
-      'libmlx4',
-      'libmthca',
-      'libnes',
-    ].each do |pkg|
+    base_pkgs.each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end
     end
 
-    [
-      'compat-dapl',
-      'infiniband-diags',
-      'libibcommon',
-      'mstflint',
-      'perftest',
-      'qperf',
-      'srptools',
-    ].each do |pkg|
+    opt_pkgs.each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end

--- a/spec/classes/infiniband_spec.rb
+++ b/spec/classes/infiniband_spec.rb
@@ -14,6 +14,26 @@ end
 
 def base_packages
   {
+    'el7.4' => [
+      'dapl',
+      'ibacm',
+      'ibutils',
+      'infiniband-diags',
+      'iwpmd',
+      'libibcm',
+      'libibmad',
+      'libibumad',
+      'libibverbs',
+      'libibverbs-utils',
+      'librdmacm',
+      'librdmacm-utils',
+      'mstflint',
+      'opa-address-resolution',
+      'opa-fastfabric',
+      'perftest',
+      'qperf',
+      'srp_daemon',
+    ],
     'el7' => [
       'dapl',
       'ibacm',
@@ -80,6 +100,15 @@ end
 
 def optional_packages
   {
+    'el7.4' => [
+      'compat-dapl',
+      'compat-opensm-libs',
+      'libibcommon',
+      'libusnic_verbs',
+      'libvma',
+      'rdma-core',
+      'usnic-tools',
+    ],
     'el7' => [
       'compat-dapl',
       'infiniband-diags',
@@ -223,6 +252,38 @@ describe 'infiniband' do
         it { should have_package_resource_count(base_packages['el7'].size) }
 
         optional_packages['el7'].each do |optional_package|
+          it { should_not contain_package(optional_package) }
+        end
+      end
+    end
+
+    context 'operatingsystemrelease => 7.4' do
+      let :facts do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemrelease     => '7.4.1708',
+          :operatingsystemmajrelease  => '7',
+          :has_infiniband             => 'true',
+          :memorysize_mb              => '64399.75',
+        }
+      end
+
+      it { should have_package_resource_count(base_packages['el7.4'].size + optional_packages['el7.4'].size) }
+
+      base_packages['el7.4'].each do |package|
+        it { should contain_package(package).with_ensure('present') }
+      end
+
+      optional_packages['el7.4'].each do |optional_package|
+        it { should contain_package(optional_package).with_ensure('present') }
+      end
+
+      context 'with_optional_packages => false' do
+        let(:params) {{ :with_optional_packages => false }}
+
+        it { should have_package_resource_count(base_packages['el7.4'].size) }
+
+        optional_packages['el7.4'].each do |optional_package|
           it { should_not contain_package(optional_package) }
         end
       end


### PR DESCRIPTION
Quite a drastic change in packaging. Some (old) packages are only
pointers to libibverbs now. Those have been ommited in the list. Other
packages moved from optional to base. New stuff has been added.

Oddities: Though package rdma-core is in optional, it gets installed
as a dependency when installing mandatory libibverbs. Looking at the
file list of package rdma-core reveals that it is actually essential for a
working IB stack IMHO.