### PR TITLE
Adds possibility to omit network service restarts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ Boolean: defaults to true.  Sets if the infiniband::interface should be enabled.
 
 String: defaults to 'yes'.  The CONNECTED_MODE for the infiniband interface.
 
+#####`notify_service`
+
+Boolean: defaults to true. By default the network service gets notified and therefore restarted
+when one or more interfaces are created, chagned or removed. If set to false, the changes
+to the config files is done without notifying the network service, which then can/must be done
+manually at a later point.
+Setting this to false also enables to use another module for handling the network service.
+
 ### Facts
 
 #### has_infiniband

--- a/spec/defines/infiniband_interface_spec.rb
+++ b/spec/defines/infiniband_interface_spec.rb
@@ -13,7 +13,7 @@ describe 'infiniband::interface' do
   let :title do
     'ib0'
   end
-  
+
   let :default_params do
     {
       :ipaddr   => '192.168.1.1',
@@ -33,13 +33,13 @@ describe 'infiniband::interface' do
       'owner'   => 'root',
       'group'   => 'root',
       'mode'    => '0644',
-      'notify'  => 'Service[network]',
     })
   end
 
   it do
     should contain_file('/etc/sysconfig/network-scripts/ifcfg-ib0') \
-      .with_content(my_fixture_read('ifcfg-ib0_with_connected_mode'))
+      .with_content(my_fixture_read('ifcfg-ib0_with_connected_mode')) \
+      .that_notifies('Service[network]')
   end
 
   context 'ensure => absent' do
@@ -80,6 +80,15 @@ describe 'infiniband::interface' do
     end
 
     it { should contain_file('/etc/sysconfig/network-scripts/ifcfg-ib0').with_content(my_fixture_read('ifcfg-ib0_with_gateway')) }
+  end
+
+  context 'notify_service => false' do
+    let :params do
+      default_params.merge({:notify_service => 'false'})
+    end
+
+    it { should_not contain_class('network') }
+    it { should_not contain_service('network') }
   end
 end
 


### PR DESCRIPTION
This change enables the following two use cases:

* Change to a IB interface should not lead to an automatic network
  service restart.
* The module is not hard-dependent on razorsedge-network anymore. Any
  other module called network providing a service resource network
  can be used.

Maybe the relationship between an IB interface configuration file and the
network service should be handled in a profile anyway.