### PR TITLE
Test for "true" and true

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -154,6 +154,11 @@ class infiniband::params {
       $service_enable = true
     }
 
+    true : {
+      $service_ensure = 'running'
+      $service_enable = true
+    }
+
     default : {
       $service_ensure = 'stopped'
       $service_enable = false

--- a/spec/classes/infiniband_spec.rb
+++ b/spec/classes/infiniband_spec.rb
@@ -369,6 +369,32 @@ describe 'infiniband' do
       })
     end
 
+    context "has_infiniband is boolean true" do
+      let :facts do
+        {
+          :osfamily                   => 'RedHat',
+          :operatingsystemrelease     => '6.6',
+          :operatingsystemmajrelease  => '6',
+          :has_infiniband             => true,
+          :memorysize_mb              => '64399.75',
+        }
+      end
+
+      it do
+        should contain_service('rdma').with({
+          'ensure'      => 'running',
+          'enable'      => 'true',
+        })
+      end
+
+      it do
+        should contain_service('ibacm').with({
+          'ensure'      => 'running',
+          'enable'      => 'true',
+        })
+      end
+    end
+
     context "has_infiniband is false" do
       let :facts do
         {


### PR DESCRIPTION
Facts in Puppet <4 are always strings while in Puppet >4 the data types
are respected. This fixes my issue on Puppet-5.3.3.