### PR TITLE
BREAKING: Use Puppet data types for parameters - drop puppet 3 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.11.0
+      ref: 4.13.1
     augeasproviders_core:
       repo: git://github.com/hercules-team/augeasproviders_core.git
     augeasproviders_shellvar:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ script: bundle exec rake release_checks
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
     - rvm: 2.1.6
       env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    - rvm: 2.4.2
+      env: PUPPET_GEM_VERSION="~> 5.0" STRICT_VARIABLES="yes"
     - rvm: 2.4.0
       sudo: required
       services: docker

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Define a IBoIP interface
 
 ##### `packages`
 
-The packges to install infiniband support.  Default is 'UNSET'.
+The packges to install infiniband support.  Default is undef.
 
-If 'UNSET' the entire set of Infiniband Support packages will be installed.
+If undef the entire set of Infiniband Support packages will be installed.
 
 ##### `with_optional_packages`
 
@@ -125,7 +125,7 @@ Sets the `NFSoRDMA_LOAD` setting for the RDMA service (defaults to 'yes').
 
 ##### `nfsordma_port`
 
-Sets the `NFSoRDMA_PORT` setting for the RDMA service (defaults to '2050').
+Sets the `NFSoRDMA_PORT` setting for the RDMA service (defaults to 2050).
 
 ##### `manage_mlx4_core_options`
 
@@ -133,13 +133,13 @@ Boolean that determines if '/etc/modprobe.d/mlx4_core.conf' should be managed (d
 
 ##### `log_num_mtt`
 
-Sets the mlx4_core module's 'log_num_mtt' value.  Defaults to 'UNSET'.
+Sets the mlx4_core module's 'log_num_mtt' value.  Defaults to undef.
 
-When the value is 'UNSET' the value is determined using the `calc_log_num_mtt` parser function.
+When the value is undef the value is determined using the `calc_log_num_mtt` parser function.
 
 ##### `log_mtts_per_seg`
 
-Sets the mlx4_core module's 'log_mtts_per_seq' value.  Defaults to '3'.
+Sets the mlx4\_core module's 'log_mtts_per_seq' value.  Defaults to 3.
 
 ##### `interfaces`
 
@@ -170,7 +170,7 @@ String: required, no default.  The NETMASK for the infiniband interface.
 
 ##### `gateway`
 
-String: defaults to 'UNSET'.  The GATEWAY for the infiniband interface.
+String: defaults to undef.  The GATEWAY for the infiniband interface.
 
 ##### `ensure`
 
@@ -183,6 +183,10 @@ Boolean: defaults to true.  Sets if the infiniband::interface should be enabled.
 ##### `connected_mode`
 
 String: defaults to 'yes'.  The CONNECTED_MODE for the infiniband interface.
+
+##### `mtu`
+
+String: defaults to undef. The MTU for the infiniband interface.
 
 ##### `notify_service`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,45 +2,33 @@
 #
 # See README.md for more details.
 class infiniband (
-  $packages                     = 'UNSET',
-  $with_optional_packages       = true,
-  $rdma_service_ensure          = $infiniband::params::service_ensure,
-  $rdma_service_enable          = $infiniband::params::service_enable,
-  $rdma_service_name            = $infiniband::params::rdma_service_name,
-  $rdma_service_has_status      = $infiniband::params::rdma_service_has_status,
-  $rdma_service_has_restart     = $infiniband::params::rdma_service_has_restart,
-  $ibacm_service_ensure         = $infiniband::params::service_ensure,
-  $ibacm_service_enable         = $infiniband::params::service_enable,
-  $ibacm_service_name           = $infiniband::params::ibacm_service_name,
-  $ibacm_service_has_status     = $infiniband::params::ibacm_service_has_status,
-  $ibacm_service_has_restart    = $infiniband::params::ibacm_service_has_restart,
-  $rdma_conf_path               = $infiniband::params::rdma_conf_path,
-  $ipoib_load                   = 'yes',
-  $srp_load                     = 'no',
-  $iser_load                    = 'no',
-  $rds_load                     = 'no',
-  $fixup_mtrr_regs              = 'no',
-  $nfsordma_load                = 'yes',
-  $nfsordma_port                = 2050,
-  $manage_mlx4_core_options     = true,
-  $log_num_mtt                  = 'UNSET',
-  $log_mtts_per_seg             = '3',
-  $interfaces                   = {},
+  Optional[Array] $packages             = undef,
+  Boolean $with_optional_packages       = true,
+  String $rdma_service_ensure           = $infiniband::params::service_ensure,
+  Boolean $rdma_service_enable          = $infiniband::params::service_enable,
+  String $rdma_service_name             = $infiniband::params::rdma_service_name,
+  Boolean $rdma_service_has_status      = $infiniband::params::rdma_service_has_status,
+  Boolean $rdma_service_has_restart     = $infiniband::params::rdma_service_has_restart,
+  String $ibacm_service_ensure          = $infiniband::params::service_ensure,
+  Boolean $ibacm_service_enable         = $infiniband::params::service_enable,
+  String $ibacm_service_name            = $infiniband::params::ibacm_service_name,
+  Boolean $ibacm_service_has_status     = $infiniband::params::ibacm_service_has_status,
+  Boolean $ibacm_service_has_restart    = $infiniband::params::ibacm_service_has_restart,
+  Stdlib::Absolutepath $rdma_conf_path  = $infiniband::params::rdma_conf_path,
+  Enum['yes', 'no'] $ipoib_load         = 'yes',
+  Enum['yes', 'no'] $srp_load           = 'no',
+  Enum['yes', 'no'] $iser_load          = 'no',
+  Enum['yes', 'no'] $rds_load           = 'no',
+  Enum['yes', 'no'] $fixup_mtrr_regs    = 'no',
+  Enum['yes', 'no'] $nfsordma_load      = 'yes',
+  Integer[0, 65535] $nfsordma_port      = 2050,
+  Boolean $manage_mlx4_core_options     = true,
+  Optional[Integer] $log_num_mtt        = undef,
+  Integer $log_mtts_per_seg             = 3,
+  Hash $interfaces                      = {},
 ) inherits infiniband::params {
 
-  validate_bool($with_optional_packages)
-  validate_re($ipoib_load, ['^yes$', '^no$'])
-  validate_re($srp_load, ['^yes$', '^no$'])
-  validate_re($iser_load, ['^yes$', '^no$'])
-  validate_re($rds_load, ['^yes$', '^no$'])
-  validate_re($fixup_mtrr_regs, ['^yes$', '^no$'])
-  validate_re($nfsordma_load, ['^yes$', '^no$'])
-  validate_bool($manage_mlx4_core_options)
-  validate_hash($interfaces)
-
-  if $packages != 'UNSET' {
-    validate_array($packages)
-
+  if $packages {
     $support_packages = $packages
   } else {
     $support_packages = $with_optional_packages ? {
@@ -51,7 +39,7 @@ class infiniband (
 
   if $manage_mlx4_core_options {
     $real_log_num_mtt = $log_num_mtt ? {
-      'UNSET' => calc_log_num_mtt($::memorysize_mb, $log_mtts_per_seg),
+      Undef   => calc_log_num_mtt($::memorysize_mb, $log_mtts_per_seg),
       default => $log_num_mtt,
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -149,16 +149,10 @@ class infiniband::params {
 
   # Set default service states based on has_infiniband fact value
   case $::has_infiniband {
-    /true/ : {
-      $service_ensure = 'running'
-      $service_enable = true
-    }
-
     true : {
       $service_ensure = 'running'
       $service_enable = true
     }
-
     default : {
       $service_ensure = 'stopped'
       $service_enable = false

--- a/metadata.json
+++ b/metadata.json
@@ -20,8 +20,11 @@
     }
   ],
   "dependencies": [
-    { "name":"puppetlabs-stdlib", "version_requirement": ">= 3.2.0 <5.0.0" },
-    { "name":"razorsedge-network", "version_requirement": "3.x" },
-    { "name":"herculesteam-augeasproviders_shellvar", "version_requirement": "2.x" }
+    { "name":"puppetlabs/stdlib", "version_requirement": ">= 4.13.1 <5.0.0" },
+    { "name":"razorsedge/network", "version_requirement": ">= 3.0.0 <4.0.0" },
+    { "name":"herculesteam/augeasproviders_shellvar", "version_requirement": ">=2.0.0 <3.0.0" }
+  ],
+  "requirements": [
+    {"name": "puppet", "version_requirement": ">= 4.7.0 < 6.0.0" }
   ]
 }

--- a/spec/classes/infiniband_spec.rb
+++ b/spec/classes/infiniband_spec.rb
@@ -146,7 +146,7 @@ describe 'infiniband' do
       :osfamily                   => 'RedHat',
       :operatingsystemrelease     => '6.5',
       :operatingsystemmajrelease  => '6',
-      :has_infiniband             => 'true',
+      :has_infiniband             => true,
       :memorysize_mb              => '64399.75',
     }
   end
@@ -263,7 +263,7 @@ describe 'infiniband' do
           :osfamily                   => 'RedHat',
           :operatingsystemrelease     => '7.4.1708',
           :operatingsystemmajrelease  => '7',
-          :has_infiniband             => 'true',
+          :has_infiniband             => true,
           :memorysize_mb              => '64399.75',
         }
       end
@@ -321,7 +321,7 @@ describe 'infiniband' do
     end
 
     context 'when log_num_mtt => 26' do
-      let(:params) {{ :manage_mlx4_core_options => true, :log_num_mtt => '26' }}
+      let(:params) {{ :manage_mlx4_core_options => true, :log_num_mtt => 26 }}
 
       it do
         verify_contents(catalogue, '/etc/modprobe.d/mlx4_core.conf', [
@@ -331,7 +331,7 @@ describe 'infiniband' do
     end
 
     context 'when log_mtts_per_seg => 1' do
-      let(:params) {{ :manage_mlx4_core_options => true, :log_mtts_per_seg => '1' }}
+      let(:params) {{ :manage_mlx4_core_options => true, :log_mtts_per_seg => 1 }}
 
       it do
         verify_contents(catalogue, '/etc/modprobe.d/mlx4_core.conf', [
@@ -401,7 +401,7 @@ describe 'infiniband' do
           :osfamily                   => 'RedHat',
           :operatingsystemrelease     => '6.6',
           :operatingsystemmajrelease  => '6',
-          :has_infiniband             => 'false',
+          :has_infiniband             => false,
           :memorysize_mb              => '64399.75',
         }
       end
@@ -436,42 +436,6 @@ describe 'infiniband' do
           'netmask' => '255.255.255.0',
         })
       end
-    end
-  end
-
-  # Test validate_bool parameters
-  [
-    'with_optional_packages',
-    'manage_mlx4_core_options',
-  ].each do |param|
-    context "with #{param} => 'foo'" do
-      let(:params) {{ param => 'foo' }}
-      it { expect { should create_class('infiniband') }.to raise_error(Puppet::Error, /is not a boolean/) }
-    end
-  end
-
-  # Test validate_re parameters
-  [
-    'ipoib_load',
-    'srp_load',
-    'iser_load',
-    'rds_load',
-    'fixup_mtrr_regs',
-    'nfsordma_load',
-  ].each do |p|
-    context "when #{p} => 'foo'" do
-      let(:params) {{ p.to_sym => 'foo' }}
-      it { expect { should create_class('infiniband') }.to raise_error(Puppet::Error, /does not match \["\^yes\$", "\^no\$"\]/) }
-    end
-  end
-
-  # Test validate_hash parameters
-  [
-    'interfaces',
-  ].each do |p|
-    context "when #{p} => 'foo'" do
-      let(:params) {{ p.to_sym => 'foo' }}
-      it { expect { should create_class('infiniband') }.to raise_error(Puppet::Error, /is not a Hash/) }
     end
   end
 end

--- a/spec/defines/infiniband_interface_spec.rb
+++ b/spec/defines/infiniband_interface_spec.rb
@@ -58,6 +58,14 @@ describe 'infiniband::interface' do
     it { should contain_file('/etc/sysconfig/network-scripts/ifcfg-ib0').with_content(my_fixture_read('ifcfg-ib0_with_onboot_no')) }
   end
 
+  context 'enable => false' do
+    let :params do
+      default_params.merge({:enable => false})
+    end
+
+    it { should contain_file('/etc/sysconfig/network-scripts/ifcfg-ib0').with_content(my_fixture_read('ifcfg-ib0_with_onboot_no')) }
+  end
+
   context 'connected_mode => no' do
     let :params do
       default_params.merge({:connected_mode => 'no'})
@@ -68,7 +76,7 @@ describe 'infiniband::interface' do
 
   context 'mtu => 65520' do
     let :params do
-      default_params.merge({:mtu => '65520'})
+      default_params.merge({:mtu => 65520})
     end
 
     it { should contain_file('/etc/sysconfig/network-scripts/ifcfg-ib0'). with_content(my_fixture_read('ifcfg-ib0_with_mtu')) }
@@ -84,7 +92,7 @@ describe 'infiniband::interface' do
 
   context 'notify_service => false' do
     let :params do
-      default_params.merge({:notify_service => 'false'})
+      default_params.merge({:notify_service => false})
     end
 
     it { should_not contain_class('network') }

--- a/spec/unit/facter/has_infiniband_spec.rb
+++ b/spec/unit/facter/has_infiniband_spec.rb
@@ -10,21 +10,21 @@ describe 'has_infiniband fact' do
 
   it "should return true when Mellanox ConnectX card" do
     Facter::Util::Infiniband.stubs(:lspci).returns(my_fixture_read('mellanox_lspci_1'))
-    Facter.fact(:has_infiniband).value.should == true
+    expect(Facter.fact(:has_infiniband).value).to eq(true)
   end
 
   it "should return true when QLogic card" do
     Facter::Util::Infiniband.stubs(:lspci).returns(my_fixture_read('qlogic_lspci_1'))
-    Facter.fact(:has_infiniband).value.should == true
+    expect(Facter.fact(:has_infiniband).value).to eq(true)
   end
 
   it "should return false when no IB device present" do
     Facter::Util::Infiniband.stubs(:lspci).returns(my_fixture_read('noib_lspci_1'))
-    Facter.fact(:has_infiniband).value.should == false
+    expect(Facter.fact(:has_infiniband).value).to eq(false)
   end
 
   it "should return true with Mellanox ConnectX-3 card" do
     Facter::Util::Infiniband.stubs(:lspci).returns(my_fixture_read('mellanox_lspci_2'))
-    Facter.fact(:has_infiniband).value.should == true
+    expect(Facter.fact(:has_infiniband).value).to eq(true)
   end
 end

--- a/spec/unit/facter/infiniband_board_id_spec.rb
+++ b/spec/unit/facter/infiniband_board_id_spec.rb
@@ -11,35 +11,35 @@ describe 'infiniband_board_id fact' do
   it "should handle a single mlx port" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0"])
     Facter::Util::Infiniband.stubs(:get_port_board_id).with("mlx4_0").returns("MT_0000000000")
-    Facter.fact(:infiniband_board_id).value.should == "MT_0000000000"
+    expect(Facter.fact(:infiniband_board_id).value).to eq("MT_0000000000")
   end
 
   it "should handle multiple mlx ports" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0","mlx4_1"])
     Facter::Util::Infiniband.stubs(:get_port_board_id).with("mlx4_0").returns("MT_0000000000")
-    Facter.fact(:infiniband_board_id).value.should == "MT_0000000000"
+    expect(Facter.fact(:infiniband_board_id).value).to eq("MT_0000000000")
   end
   
   it "should handle a single qib port" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["qib0"])
     Facter::Util::Infiniband.stubs(:get_port_board_id).with("qib0").returns("InfiniPath_QLE0000")
-    Facter.fact(:infiniband_board_id).value.should == "InfiniPath_QLE0000"
+    expect(Facter.fact(:infiniband_board_id).value).to eq("InfiniPath_QLE0000")
   end
   
   it "should handle multiple mlx ports" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["qib0","qib1"])
     Facter::Util::Infiniband.stubs(:get_port_board_id).with("qib0").returns("InfiniPath_QLE0000")
-    Facter.fact(:infiniband_board_id).value.should == "InfiniPath_QLE0000"
+    expect(Facter.fact(:infiniband_board_id).value).to eq("InfiniPath_QLE0000")
   end
 
   it "should return nil for unknown port name" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["foo"])
     Facter::Util::Infiniband.stubs(:get_port_board_id).with("foo").returns(nil)
-    Facter.fact(:infiniband_board_id).value.should == nil
+    expect(Facter.fact(:infiniband_board_id).value).to be_nil
   end
 
   it "should return nil if no ports found" do
     Facter::Util::Infiniband.stubs(:get_ports).returns([])
-    Facter.fact(:infiniband_board_id).value.should == nil
+    expect(Facter.fact(:infiniband_board_id).value).to be_nil
   end
 end

--- a/spec/unit/facter/infiniband_fw_version_spec.rb
+++ b/spec/unit/facter/infiniband_fw_version_spec.rb
@@ -11,35 +11,35 @@ describe 'infiniband_fw_version fact' do
   it "should handle a single mlx port" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0"])
     Facter::Util::Infiniband.stubs(:get_port_fw_version).with("mlx4_0").returns("2.9.1200")
-    Facter.fact(:infiniband_fw_version).value.should == "2.9.1200"
+    expect(Facter.fact(:infiniband_fw_version).value).to eq("2.9.1200")
   end
 
   it "should handle multiple mlx ports" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0","mlx4_1"])
     Facter::Util::Infiniband.stubs(:get_port_fw_version).with("mlx4_0").returns("2.9.1200")
-    Facter.fact(:infiniband_fw_version).value.should == "2.9.1200"
+    expect(Facter.fact(:infiniband_fw_version).value).to eq("2.9.1200")
   end
   
   it "should handle a single qib port" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["qib0"])
     Facter::Util::Infiniband.stubs(:get_port_fw_version).with("qib0").returns("1.11")
-    Facter.fact(:infiniband_fw_version).value.should == "1.11"
+    expect(Facter.fact(:infiniband_fw_version).value).to eq("1.11")
   end
   
   it "should handle multiple mlx ports" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["qib0","qib1"])
     Facter::Util::Infiniband.stubs(:get_port_fw_version).with("qib0").returns("1.11")
-    Facter.fact(:infiniband_fw_version).value.should == "1.11"
+    expect(Facter.fact(:infiniband_fw_version).value).to eq("1.11")
   end
 
   it "should return nil for unknown port name" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["foo"])
     Facter::Util::Infiniband.stubs(:get_port_fw_version).with("foo").returns(nil)
-    Facter.fact(:infiniband_fw_version).value.should == nil
+    expect(Facter.fact(:infiniband_fw_version).value).to be_nil
   end
 
   it "should return nil if no ports found" do
     Facter::Util::Infiniband.stubs(:get_ports).returns([])
-    Facter.fact(:infiniband_fw_version).value.should == nil
+    expect(Facter.fact(:infiniband_fw_version).value).to be_nil
   end
 end

--- a/spec/unit/facter/infiniband_rate_spec.rb
+++ b/spec/unit/facter/infiniband_rate_spec.rb
@@ -11,23 +11,23 @@ describe 'infiniband_rate fact' do
   it "should handle a single port" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0"])
     Facter::Util::Infiniband.stubs(:get_port_rate).with("mlx4_0").returns("20 Gb/sec (4X DDR)")
-    Facter.fact(:infiniband_rate).value.should == "20"
+    expect(Facter.fact(:infiniband_rate).value).to eq("20")
   end
 
   it "should handle multiple ports" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["mlx4_0","mlx4_1"])
     Facter::Util::Infiniband.stubs(:get_port_rate).with("mlx4_0").returns("20 Gb/sec (4X DDR)")
-    Facter.fact(:infiniband_rate).value.should == "20"
+    expect(Facter.fact(:infiniband_rate).value).to eq("20")
   end
   
   it "should return nil for unknown port name" do
     Facter::Util::Infiniband.stubs(:get_ports).returns(["foo"])
     Facter::Util::Infiniband.stubs(:get_port_rate).with("foo").returns(nil)
-    Facter.fact(:infiniband_rate).value.should == nil
+    expect(Facter.fact(:infiniband_rate).value).to be_nil
   end
 
   it "should return nil if no ports found" do
     Facter::Util::Infiniband.stubs(:get_ports).returns([])
-    Facter.fact(:infiniband_rate).value.should == nil
+    expect(Facter.fact(:infiniband_rate).value).to be_nil
   end
 end

--- a/spec/unit/facter/util/infiniband_spec.rb
+++ b/spec/unit/facter/util/infiniband_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Util::Infiniband do
   describe 'lspci' do
     it 'should return output' do
       Facter::Util::Resolution.expects(:exec).with('lspci -n 2>/dev/null').returns("foo")
-      Facter::Util::Infiniband.lspci.should == "foo"
+      expect(Facter::Util::Infiniband.lspci).to eq("foo")
     end
   end
 
@@ -19,13 +19,13 @@ describe Facter::Util::Infiniband do
     it 'should return output' do
       File.expects(:exist?).with('/sys/class/infiniband/mlx4_0/fw_ver').returns(true)
       Facter::Util::Resolution.expects(:exec).with("cat /sys/class/infiniband/mlx4_0/fw_ver").returns("2.9.1200\n")
-      Facter::Util::Infiniband.read_sysfs("/sys/class/infiniband/mlx4_0/fw_ver").should == "2.9.1200"
+      expect(Facter::Util::Infiniband.read_sysfs("/sys/class/infiniband/mlx4_0/fw_ver")).to eq("2.9.1200")
     end
 
     it 'should return nil' do
       File.expects(:exist?).with('/sys/class/infiniband/mlx4_0/fw_ver').returns(true)
       Facter::Util::Resolution.expects(:exec).with("cat /sys/class/infiniband/mlx4_0/fw_ver").returns(nil)
-      Facter::Util::Infiniband.read_sysfs("/sys/class/infiniband/mlx4_0/fw_ver").should == nil
+      expect(Facter::Util::Infiniband.read_sysfs("/sys/class/infiniband/mlx4_0/fw_ver")).to be_nil
     end
   end
 
@@ -33,64 +33,64 @@ describe Facter::Util::Infiniband do
     it 'should return 1' do
       Facter::Util::Resolution.expects(:which).with('lspci').returns(true)
       Facter::Util::Infiniband.expects(:lspci).with().returns(my_fixture_read('mellanox_lspci_1'))
-      Facter::Util::Infiniband.count_ib_devices.should == 1
+      expect(Facter::Util::Infiniband.count_ib_devices).to eq(1)
     end
 
     it 'should return 0' do
       Facter::Util::Resolution.expects(:which).with('lspci').returns(true)
       Facter::Util::Infiniband.expects(:lspci).with().returns(my_fixture_read('noib_lspci_1'))
-      Facter::Util::Infiniband.count_ib_devices.should == 0
+      expect(Facter::Util::Infiniband.count_ib_devices).to eq(0)
     end
 
     it 'should return 0' do
       Facter::Util::Resolution.expects(:which).with('lspci').returns(false)
-      Facter::Util::Infiniband.count_ib_devices.should == 0
+      expect(Facter::Util::Infiniband.count_ib_devices).to eq(0)
     end
   end
 
   describe 'get_port_fw_version' do
     it 'should return fw_ver for mlx devices' do
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/fw_ver").returns("2.9.1200")
-      Facter::Util::Infiniband.get_port_fw_version("mlx4_0").should == "2.9.1200"
+      expect(Facter::Util::Infiniband.get_port_fw_version("mlx4_0")).to eq("2.9.1200")
     end
 
     it 'should return nil' do
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/fw_ver").returns(nil)
-      Facter::Util::Infiniband.get_port_fw_version("mlx4_0").should == nil
+      expect(Facter::Util::Infiniband.get_port_fw_version("mlx4_0")).to be_nil
     end
 
     it 'should return nil' do
       Facter::Util::Infiniband.expects(:read_sysfs).never
-      Facter::Util::Infiniband.get_port_fw_version("foo").should == nil
+      expect(Facter::Util::Infiniband.get_port_fw_version("foo")).to be_nil
     end
   end
 
   describe 'get_port_board_id' do
     it 'should return board_id' do
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/board_id").returns("MT_0000000000")
-      Facter::Util::Infiniband.get_port_board_id("mlx4_0").should == "MT_0000000000"
+      expect(Facter::Util::Infiniband.get_port_board_id("mlx4_0")).to eq("MT_0000000000")
     end
 
     it 'should return nil' do
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/fw_ver").returns(nil)
-      Facter::Util::Infiniband.get_port_fw_version("mlx4_0").should == nil
+      expect(Facter::Util::Infiniband.get_port_fw_version("mlx4_0")).to be_nil
     end
   end
 
   describe 'get_ports' do
     it "should return a array with single port name" do
       Dir.stubs(:glob).with("/sys/class/infiniband/*").returns(["/sys/class/infiniband/mlx4_0"])
-      Facter::Util::Infiniband.get_ports.should == ["mlx4_0"]
+      expect(Facter::Util::Infiniband.get_ports).to eq(["mlx4_0"])
     end
 
     it "should return a array with two port names" do
       Dir.stubs(:glob).with("/sys/class/infiniband/*").returns(["/sys/class/infiniband/mlx4_0","/sys/class/infiniband/mlx4_1"])
-      Facter::Util::Infiniband.get_ports.should == ["mlx4_0","mlx4_1"]
+      expect(Facter::Util::Infiniband.get_ports).to eq(["mlx4_0","mlx4_1"])
     end
 
     it "should return empty array if no ports exist" do
       Dir.stubs(:glob).with("/sys/class/infiniband/*").returns([])
-      Facter::Util::Infiniband.get_ports.should == []
+      expect(Facter::Util::Infiniband.get_ports).to eq([])
     end
   end
 
@@ -98,18 +98,18 @@ describe Facter::Util::Infiniband do
     it 'should return rate for DDR device' do
       Dir.expects(:glob).with('/sys/class/infiniband/mlx4_0/ports/*').returns(['/sys/class/infiniband/mlx4_0/ports/1'])
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/ports/1/rate").returns("20 Gb/sec (4X DDR)")
-      Facter::Util::Infiniband.get_port_rate("mlx4_0").should == "20 Gb/sec (4X DDR)"
+      expect(Facter::Util::Infiniband.get_port_rate("mlx4_0")).to eq("20 Gb/sec (4X DDR)")
     end
 
     it 'should return nil when Dir.glob is empty' do
       Dir.expects(:glob).with('/sys/class/infiniband/mlx4_0/ports/*').returns([])
-      Facter::Util::Infiniband.get_port_rate("mlx4_0").should == nil
+      expect(Facter::Util::Infiniband.get_port_rate("mlx4_0")).to be_nil
     end
 
     it 'should return nil when read_sysfs is nil' do
       Dir.expects(:glob).with('/sys/class/infiniband/mlx4_0/ports/*').returns(['/sys/class/infiniband/mlx4_0/ports/1'])
       Facter::Util::Infiniband.expects(:read_sysfs).with("/sys/class/infiniband/mlx4_0/ports/1/rate").returns(nil)
-      Facter::Util::Infiniband.get_port_rate("mlx4_0").should == nil
+      expect(Facter::Util::Infiniband.get_port_rate("mlx4_0")).to be_nil
     end
   end
 end

--- a/templates/ifcfg.erb
+++ b/templates/ifcfg.erb
@@ -5,10 +5,10 @@ ONBOOT="<%= @onboot %>"
 TYPE="InfiniBand"
 IPADDR="<%= @ipaddr %>"
 NETMASK="<%= @netmask %>"
-<% if @gateway != 'UNSET' -%>
+<% if @gateway -%>
 GATEWAY="<%= @gateway %>"
 <% end -%>
 CONNECTED_MODE="<%= @connected_mode %>"
-<% if @mtu != 'UNSET' -%>
+<% if @mtu -%>
 MTU="<%= @mtu %>"
 <% end -%>


### PR DESCRIPTION
* Change packages default from 'UNSET' to undef
* Change log_num_mtt default from 'UNSET' to undef
* Change log_mtts_per_seg default to Integer, value is the same
* Update infiniband::interface gateway and mtu from 'UNSET' to undef
* Increase minimum supported stdlib to 4.13.1