### PR TITLE
Add initial support for multiple infiniband ports and a new fact for mapping network device names and related IB device information

### DIFF
--- a/lib/facter/infiniband_netdevs.rb
+++ b/lib/facter/infiniband_netdevs.rb
@@ -1,0 +1,19 @@
+# Fact: infiniband_netdevs
+#
+# Purpose: Report the network device names and information
+#
+# Resolution:
+#   Returns a hash of netdevice names (ib0) with a hash of data about the device
+#
+# Caveats:
+#   Only tested on systems with Mellanox cards
+#
+
+require 'facter/util/infiniband'
+
+Facter.add(:infiniband_netdevs) do
+  confine :has_infiniband => true
+  setcode do
+    Facter::Util::Infiniband.get_netdev_to_hcaport
+  end
+end

--- a/lib/facter/util/infiniband.rb
+++ b/lib/facter/util/infiniband.rb
@@ -169,6 +169,20 @@ class Facter::Util::Infiniband
     state[/: (.*)/,1]
   end
 
+  # Returns link layer of Infiniband port (Ethernet or InfiniBand)
+  #
+  # @return [String]
+  #
+  # @api private
+  def self.get_real_port_linklayer(hca, port)
+    port_sysfs_path = Dir.glob(File.join('/sys/class/infiniband', hca, 'ports', port)) 
+    return nil if port_sysfs_path.nil?
+    
+    linklayer_sysfs_path = File.join(port_sysfs_path, 'link_layer')
+    linklayer = self.read_sysfs(linklayer_sysfs_path)
+    linklayer
+  end
+
   # Returns hash of net device names (ib0, p1p1) and data about each
   #
   # @return [Hash]
@@ -186,7 +200,8 @@ class Facter::Util::Infiniband
         'hca' => split[0],
         'port' => split[2],
         'state' => self.get_real_port_state(split[0], split[2]),
-        'rate' => self.get_real_port_rate(split[0], split[2])
+        'rate' => self.get_real_port_rate(split[0], split[2]),
+        'link_layer' => self.get_real_port_linklayer(split[0], split[2]),
       }
 
     end


### PR DESCRIPTION
A couple of new util functions for getting rate and state information for a specific hca and port. As well as one that pulls information from ibdev2netdev and creates a hash with port information:

{
  ib0 => {
    hca => "mlx4_0",
    port => "1",
    state => "ACTIVE",
    rate => "40"
  },
  ib1 => {
    hca => "mlx4_0",
    port => "2",
    state => "DOWN",
    rate => "10"
  }
}

Then a new fact (infiniband_netdev) that returns that hash
