### PR TITLE
Bump dep augeasproviders shellvar

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "herculesteam/augeasproviders_shellvar",
-      "version_requirement": ">=2.0.0 <4.0.0"
+      "version_requirement": ">=2.0.0 <5.0.0"
     },
     {
       "name": "puppet/yum",

--- a/spec/unit/facter/util/infiniband_spec.rb
+++ b/spec/unit/facter/util/infiniband_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'facter/util/file_read'
 require 'facter/util/infiniband'
 
 describe Facter::Util::Infiniband do


### PR DESCRIPTION
The first commit in this PR fixes the unit tests. The second commit then bumps the upper limit of the requied versions for augeasproviders_shellvar to the next major versions. All tests green:

```
$ pdk test unit
pdk (WARN): This module is compatible with an older version of PDK. Run `pdk update` to update it to your version of PDK.
pdk (INFO): Using Ruby 2.5.9
pdk (INFO): Using Puppet 6.24.0
[✔] Preparing to run the unit tests.
/opt/puppetlabs/pdk/private/ruby/2.5.9/bin/ruby -I/opt/puppetlabs/pdk/share/cache/ruby/2.5.0/gems/rspec-core-3.10.1/lib:/opt/puppetlabs/pdk/share/cache/ruby/2.5.0/gems/rspec-support-3.10.2/lib /opt/puppetlabs/pdk/share/cache/ruby/2.5.0/gems/rspec-core-3.10.1/exe/rspec --pattern spec
/\{aliases,classes,defines,functions,hosts,integration,plans,tasks,type_aliases,types,unit\}/\*\*/\*_spec.rb --format progress
Run options: exclude {:bolt=>true}
.......................................................................................................................................................................................................................................

Finished in 37.57 seconds (files took 10.13 seconds to load)
231 examples, 0 failures

```